### PR TITLE
Conditionally require crypto module in shim.js

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -20,3 +20,9 @@ process.env['NODE_ENV'] = isDev ? 'development' : 'production'
 if (typeof localStorage !== 'undefined') {
   localStorage.debug = isDev ? '*' : ''
 }
+
+// Make sure crypto gets loaded first, so it can populate global.crypto
+if (require('./package.json').dependencies['react-native-crypto']) {
+  let cryptoModule = 'crypto'
+  const crypto = require(cryptoModule)
+}

--- a/shim.js
+++ b/shim.js
@@ -23,6 +23,8 @@ if (typeof localStorage !== 'undefined') {
 
 // Make sure crypto gets loaded first, so it can populate global.crypto
 if (require('./package.json').dependencies['react-native-crypto']) {
+  // Placing the module name in a variable prevents 'crypto' from being
+  // pre-loaded (which could cause an error, since it may not exist)
   let cryptoModule = 'crypto'
   const crypto = require(cryptoModule)
 }


### PR DESCRIPTION
Fixes the issue discussed here: https://github.com/tradle/react-native-crypto/pull/22. Basically, sometimes we need to require('crypto') before anything else, and shim.js is the best place to do that.