### PR TITLE
Remove dynamic require, and explain in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,8 @@ rn-nodeify will create a `shim.js` file in your project root directory. The firs
 import './shim'
 ```
 
+If you are using the crypto shim, you will need to manually uncomment the line to `require('crypto')` in `shim.js`, this is because as of react-native 0.49, dynamically requiring a library is no longer allowed.
+
 Some shims may require linking libraries, be sure to run `react-native link` after installing new shims if you run into problems.
 
 ### Example Apps / Workflows

--- a/shim.js
+++ b/shim.js
@@ -21,10 +21,6 @@ if (typeof localStorage !== 'undefined') {
   localStorage.debug = isDev ? '*' : ''
 }
 
-// Make sure crypto gets loaded first, so it can populate global.crypto
-if (require('./package.json').dependencies['react-native-crypto']) {
-  // Placing the module name in a variable prevents 'crypto' from being
-  // pre-loaded (which could cause an error, since it may not exist)
-  let cryptoModule = 'crypto'
-  const crypto = require(cryptoModule)
-}
+// If using the crypto shim, uncomment the following line to ensure
+// crypto is loaded first, so it can populate global.crypto
+// require('crypto')


### PR DESCRIPTION
Remove the dynamic require from shim.js, and add a comment in the README to explain that it must be manually uncommented if needed.

See: https://github.com/tradle/rn-nodeify/issues/59