### PR TITLE
Polite github url

### DIFF
--- a/shims.js
+++ b/shims.js
@@ -10,7 +10,7 @@ module.exports = {
   "dns.js": "^1.0.1",
   "domain-browser": "^1.1.1",
   "events": "^1.0.0",
-  "react-native-http": "tradle/react-native-http#834492d",
+  "react-native-http": "git+https://github.com/tradle/react-native-http#834492d",
   "https-browserify": "~0.0.0",
   "react-native-os": "^1.0.1",
   "path-browserify": "0.0.0",


### PR DESCRIPTION
Fix stacking issue while installing react-native-http

Error Log:

```
(*'-') < cat ~/.npm/_logs/2018-02-03T06_23_59_721Z-debug.log
0 info it worked if it ends with ok
1 verbose cli [ '/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/bin/node',
1 verbose cli   '/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/bin/npm',
1 verbose cli   'install',
1 verbose cli   '--save',
1 verbose cli   'tradle/react-native-http#834492d' ]
2 info using npm@5.6.0
3 info using node@v9.5.0
4 verbose npm-session 30833c6df2c74f16
5 silly install loadCurrentTree
6 silly install readLocalPackageData
7 info lifecycle react-native-http@1.0.0~prepack: react-native-http@1.0.0
8 silly fetchPackageMetaData error for github:tradle/react-native-http#834492d Non-registry package missing package.json: github:tradle/react-native-http#834492d.
9 verbose stack Error: Non-registry package missing package.json: github:tradle/react-native-http#834492d.
9 verbose stack     at BB.join (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/pacote/lib/finalize-manifest.js:160:23)
9 verbose stack     at tryCatcher (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/bluebird/js/release/util.js:16:23)
9 verbose stack     at Holder$5._callFunction (eval at generateHolderClass (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/bluebird/js/release/join.js:92:16), <anonymous>:14:44)
9 verbose stack     at Holder$5.checkFulfillment (eval at generateHolderClass (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/bluebird/js/release/join.js:92:16), <anonymous>:29:30)
9 verbose stack     at Promise.eval (eval at thenCallback (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/bluebird/js/release/join.js:14:16), <anonymous>:6:20)
9 verbose stack     at Promise._settlePromise (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:566:21)
9 verbose stack     at Promise._settlePromise0 (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:614:10)
9 verbose stack     at Promise._settlePromises (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:693:18)
9 verbose stack     at Promise._fulfill (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:638:18)
9 verbose stack     at Object.<anonymous> (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/bluebird/js/release/nodeback.js:42:21)
9 verbose stack     at Object.emit (events.js:165:20)
9 verbose stack     at Object.Parser.on._ (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/tar/lib/parse.js:75:14)
9 verbose stack     at Object.emit (events.js:160:13)
9 verbose stack     at Object.[emit] (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/tar/lib/parse.js:229:12)
9 verbose stack     at Object.[maybeEnd] (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/tar/lib/parse.js:338:17)
9 verbose stack     at Object.[consumeChunk] (/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/lib/node_modules/npm/node_modules/tar/lib/parse.js:346:21)
10 verbose cwd /Users/kenta/local/src/***
11 verbose Darwin 16.7.0
12 verbose argv "/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/bin/node" "/Users/kenta/.anyenv/envs/ndenv/versions/v9.5.0/bin/npm" "install" "--save" "tradle/react-native-http#834492d"
13 verbose node v9.5.0
14 verbose npm  v5.6.0
15 error code ENOPACKAGEJSON
16 error package.json Non-registry package missing package.json: github:tradle/react-native-http#834492d.
17 error package.json npm can't find a package.json file in your current directory.
18 verbose exit [ 1, true ]
```

