### PR TITLE
Add ignore option

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -265,6 +265,13 @@ function hackPackageJSONs (modules, done) {
   finder.on('file', function (file) {
     if (path.basename(file) !== 'package.json') return
 
+    if (argv.ignore) {
+        var toIgnore = argv.ignore.split(',')
+        var rootModuleName = file.replace(/^node_modules\//, '').split('/')[0]
+        if (toIgnore.includes(rootModuleName)) {
+            return
+        }
+    }
     fixPackageJSON(modules, file, true)
   })
 

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ rn-nodeify <options>
 --install     install node core shims (default: install all), fix the "browser"
               and "react-native" fields in the package.json's of dependencies
 --hack        hack individual packages that are known to make the React Native packager choke
+--ignore      packages from root package.json to be ignored by nodeify, usefull when using custom modules using `npm link`
 ```
 
 ### Examples


### PR DESCRIPTION
* The goal of this PR is to allow ignoring some modules on which nodeify can fail with errors. For example custom modules added using `npm link`.