### PR TITLE
fix: unexpected token pbkdf2

### DIFF
--- a/pkg-hacks.js
+++ b/pkg-hacks.js
@@ -520,7 +520,7 @@ var hackers = [
     hack: function (file, contents) {
       if (isInReactNative(file)) return
 
-      var fixed = contents.replace(/process.version/g, '"' + process.version + '"')
+      var fixed = contents.replace(/\.+process\.version/g, '["' + process.version + '"]')
 
       return contents === fixed ? null : fixed
     }

--- a/pkg-hacks.js
+++ b/pkg-hacks.js
@@ -519,8 +519,11 @@ var hackers = [
     regex: [/pbkdf2/],
     hack: function (file, contents) {
       if (isInReactNative(file)) return
-
-      var fixed = contents.replace(/\.+process\.version/g, '["' + process.version + '"]')
+      
+      var replacement = 'global["' + process.version + '"]'
+      var fixed = contents
+        .replace(/global.process.version/g, replacement)
+        .replace(/process.version/g, replacement)
 
       return contents === fixed ? null : fixed
     }


### PR DESCRIPTION
resolve #102

the hacked code for pbkdf2 producing invalid syntax

![Screen Shot 2021-04-10 at 07 02 13](https://user-images.githubusercontent.com/10051243/114251273-aecc4c00-99ca-11eb-8cbe-3cd2865cc11c.png)

I think the code should be `global["v14.15.1"]` instead