### PR TITLE
fix: pbkdf2 hack not breaking in specific versions

### DIFF
--- a/pkg-hacks.js
+++ b/pkg-hacks.js
@@ -520,7 +520,9 @@ var hackers = [
     hack: function (file, contents) {
       if (isInReactNative(file)) return
 
-      var fixed = contents.replace(/process.version/g, '"' + process.version + '"')
+      var fixed = contents
+        .replace(/global\.process\.version/g, '"' + process.version + '"')
+        .replace(/process.version/g, '"' + process.version + '"')
 
       return contents === fixed ? null : fixed
     }

--- a/pkg-hacks.js
+++ b/pkg-hacks.js
@@ -522,7 +522,7 @@ var hackers = [
 
       var fixed = contents
         .replace(/global\.process\.version/g, '"' + process.version + '"')
-        .replace(/process.version/g, '"' + process.version + '"')
+        .replace(/process\.version/g, '"' + process.version + '"')
 
       return contents === fixed ? null : fixed
     }


### PR DESCRIPTION
This fixes #104 and #102  and it is the suggested implementation of #103.

I've tested it for both cases (`process.version` and `global.process.version`) and it just replaces it with the actual version number as a string (which is intended I think).